### PR TITLE
Use `tr` instead of `sed` for compatibility

### DIFF
--- a/ame.sh
+++ b/ame.sh
@@ -35,13 +35,13 @@ function ame_print() {
 
 function ame_last() {
     LAST=`curl -s http://tokyo-ame.jwa.or.jp/scripts/mesh_index.js \
-           |sed -e 's/[^0-9,]//g' -e 's/,/\n/g'|head -1`
+           |sed -e 's/[^0-9,]//g' |tr -s ',' '\n' |head -1`
     ame_print "${LAST}"
 }
 
 function ame_play() {
     INDEX=`curl -s http://tokyo-ame.jwa.or.jp/scripts/mesh_index.js \
-         |sed -e 's/[^0-9,]//g' -e 's/,/\n/g'|tac`
+         |sed -e 's/[^0-9,]//g' |tr -s ',' '\n' |tac`
     declare -a TIMES=()
     for t in $INDEX; do
         TIMES+=( ${t} )


### PR DESCRIPTION
The `sed` command bundled in Mac OS X treats `\n` as just string "\n", not a newline.

ref: http://nlfiedler.github.io/2010/12/05/newlines-in-sed-on-mac.html

----

```
$ curl -s http://tokyo-ame.jwa.or.jp/scripts/mesh_index.js | sed -e 's/[^0-9,]//g' -e 's/,/\n/g'
```

Expected:
```
201612020155
201612020150
201612020145
201612020140
201612020135
201612020130
201612020125
201612020120
201612020115
201612020110
201612020105
201612020100
201612020055
201612020050
201612020045
201612020040
201612020035
201612020030
201612020025
201612020020
201612020015
201612020010
201612020005
201612020000
201612012355
```

Actual
```
201612020155n201612020150n201612020145n201612020140n201612020135n201612020130n201612020125n201612020120n201612020115n201612020110n201612020105n201612020100n201612020055n201612020050n201612020045n201612020040n201612020035n201612020030n201612020025n201612020020n201612020015n201612020010n201612020005n201612020000n201612012355
```